### PR TITLE
more efficient Creep.prototype.getActiveBodyparts

### DIFF
--- a/screeps-perf.js
+++ b/screeps-perf.js
@@ -19,6 +19,23 @@ module.exports = function(options) {
       lastMemoryCleanUp: Game.time
     };
 
+    /**
+     * Creep method optimizations
+     */
+    Creep.prototype.getActiveBodyparts = function (type) {
+      let count = 0;
+      for (let i = this.body.length; i-- > 0;) {
+        if (this.body[i].hits > 0) {
+          if (this.body[i].type == type) {
+            count++;
+          }
+        } else {
+          break;
+        }
+      }
+      return count;
+    };
+
     if (options.speedUpArrayFunctions || options.speedUpArrayFunctions === undefined) {
       Array.prototype.filter = function(callback, thisArg) {
         var results = [];


### PR DESCRIPTION
The built-in method uses _.filter().length which wastefully creates a whole new list in memory to measure the length of. The quick fix was to use _.sum(), but I went with a whole custom function so that I could short circuit after the first damaged part and return sooner on damaged creeps.
